### PR TITLE
Modify ansible vars to allow python3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ssh.yaml"
+    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3" }
   end
 
 end


### PR DESCRIPTION
Does not work on base ubuntu bionic 64 image: '/usr/bin/python not found'