### PR TITLE
etcd: Fix ownership of the etcd binaries

### DIFF
--- a/roles/etcd/tasks/main.yaml
+++ b/roles/etcd/tasks/main.yaml
@@ -4,6 +4,8 @@
     remote_src: yes
     src: https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
     dest: /usr/local/bin/
+    owner: root
+    group: root
     exclude:
       - Documentation
       - README-etcdctl.md


### PR DESCRIPTION
Without this, the etcd binaries are owned by 1000:1000